### PR TITLE
802.11n assocation problems fixed. WMM fields added in mgmt frames

### DIFF
--- a/elements/empower/empowerassociationresponder.cc
+++ b/elements/empower/empowerassociationresponder.cc
@@ -429,6 +429,7 @@ void EmpowerAssociationResponder::send_association_response(EtherAddress dst,
 											  2 + WIFI_RATES_MAXSIZE + /* xrates */
 											  2 + 26 + /* ht capabilities */
 											  2 + 22 + /* ht information */
+											  2 + 24 + /* wmm parameter element */
 											  0;
 
 	WritablePacket *p = Packet::make(max_len);
@@ -528,12 +529,14 @@ void EmpowerAssociationResponder::send_association_response(EtherAddress dst,
 		ht->rx_supported_mcs[0] = 0xff; /* MCS 0-7 */
 		ht->rx_supported_mcs[1] = 0xff; /* MCS 8-15 */
 
+		ht->ht_extended_caps = 0x0400;
+
 		ptr += 2 + WIFI_HT_CAPS_SIZE;
 		actual_length += 2 + WIFI_HT_CAPS_SIZE;
 
 		/* ht information */
 		struct click_wifi_ht_info *ht_info = (struct click_wifi_ht_info *) ptr;
-		ht_info->type = WIFI_HT_INFO_TYPE;
+		ht_info->type = WIFI_ELEMID_HTINFO;
 		ht_info->len = WIFI_HT_INFO_SIZE;
 
 		ht_info->primary_channel = (uint8_t) channel;
@@ -544,6 +547,38 @@ void EmpowerAssociationResponder::send_association_response(EtherAddress dst,
 		ptr += 2 + WIFI_HT_INFO_SIZE;
 		actual_length += 2 + WIFI_HT_INFO_SIZE;
 
+		struct click_wifi_wmm *wmm_info = (struct click_wifi_wmm *) ptr;
+
+		wmm_info->tag_type = WIFI_ELEMID_VENDOR;
+		wmm_info->len = WIFI_WME_LEN;
+
+		const char* oui_temp = WIFI_WME_OUI;
+		memcpy(wmm_info->oui, oui_temp, WIFI_WME_OUI_LEN);
+
+		wmm_info->type = WIFI_WME_TYPE;
+		wmm_info->subtype = WIFI_WME_SUBTYPE;
+		wmm_info->version = WIFI_WME_VERSION;
+		wmm_info->qosinfo = (1 << WIFI_WME_APSD_SHIFT) | WIFI_WME_APSD_MASK;
+		wmm_info->reserved = 0x0;
+
+		wmm_info->acparam[0].aci = WIFI_WME_AC_BE_ACI;
+		wmm_info->acparam[0].ecw = WIFI_WME_AC_BE_ECW;
+		wmm_info->acparam[0].txop = WIFI_WME_AC_BE_TXOP;
+
+		wmm_info->acparam[1].aci = WIFI_WME_AC_BK_ACI;
+		wmm_info->acparam[1].ecw = WIFI_WME_AC_BK_ECW;
+		wmm_info->acparam[1].txop = WIFI_WME_AC_BK_TXOP;
+
+		wmm_info->acparam[2].aci = WIFI_WME_AC_VI_ACI;
+		wmm_info->acparam[2].ecw = WIFI_WME_AC_VI_ECW;
+		wmm_info->acparam[2].txop = WIFI_WME_AC_VI_TXOP;
+
+		wmm_info->acparam[3].aci = WIFI_WME_AC_VO_ACI;
+		wmm_info->acparam[3].ecw = WIFI_WME_AC_VO_ECW;
+		wmm_info->acparam[3].txop = WIFI_WME_AC_VO_TXOP;
+
+		ptr += 2 + WIFI_WME_LEN;
+		actual_length += 2 + WIFI_WME_LEN;
 	}
 
 	p->take(max_len - actual_length);

--- a/elements/empower/empowerbeaconsource.cc
+++ b/elements/empower/empowerbeaconsource.cc
@@ -164,6 +164,7 @@ void EmpowerBeaconSource::send_beacon(EtherAddress dst, EtherAddress bssid,
 		2 + 4 + /* tim */
 		2 + 26 + /* ht capabilities */
 		2 + 22 + /* ht information */
+		2 + 24 + /* wmm parameter element */
 		0;
 
 	// this is an actual LVAP and the CSA is active, notice that CSA will not
@@ -324,12 +325,14 @@ void EmpowerBeaconSource::send_beacon(EtherAddress dst, EtherAddress bssid,
 		ht->rx_supported_mcs[0] = 0xff; /* MCS 0-7 */
 		ht->rx_supported_mcs[1] = 0xff; /* MCS 8-15 */
 
+		ht->ht_extended_caps = 0x0400;
+
 		ptr += 2 + WIFI_HT_CAPS_SIZE;
 		actual_length += 2 + WIFI_HT_CAPS_SIZE;
 
 		/* ht information */
 		struct click_wifi_ht_info *ht_info = (struct click_wifi_ht_info *) ptr;
-		ht_info->type = WIFI_HT_INFO_TYPE;
+		ht_info->type = WIFI_ELEMID_HTINFO;
 		ht_info->len = WIFI_HT_INFO_SIZE;
 
 		ht_info->primary_channel = (uint8_t) channel;
@@ -340,6 +343,38 @@ void EmpowerBeaconSource::send_beacon(EtherAddress dst, EtherAddress bssid,
 		ptr += 2 + WIFI_HT_INFO_SIZE;
 		actual_length += 2 + WIFI_HT_INFO_SIZE;
 
+		struct click_wifi_wmm *wmm_info = (struct click_wifi_wmm *) ptr;
+
+		wmm_info->tag_type = WIFI_ELEMID_VENDOR;
+		wmm_info->len = WIFI_WME_LEN;
+
+		const char* oui_temp = WIFI_WME_OUI;
+		memcpy(wmm_info->oui, oui_temp, WIFI_WME_OUI_LEN);
+
+		wmm_info->type = WIFI_WME_TYPE;
+		wmm_info->subtype = WIFI_WME_SUBTYPE;
+		wmm_info->version = WIFI_WME_VERSION;
+		wmm_info->qosinfo = (1 << WIFI_WME_APSD_SHIFT) | WIFI_WME_APSD_MASK;
+		wmm_info->reserved = 0x0;
+
+		wmm_info->acparam[0].aci = WIFI_WME_AC_BE_ACI;
+		wmm_info->acparam[0].ecw = WIFI_WME_AC_BE_ECW;
+		wmm_info->acparam[0].txop = WIFI_WME_AC_BE_TXOP;
+
+		wmm_info->acparam[1].aci = WIFI_WME_AC_BK_ACI;
+		wmm_info->acparam[1].ecw = WIFI_WME_AC_BK_ECW;
+		wmm_info->acparam[1].txop = WIFI_WME_AC_BK_TXOP;
+
+		wmm_info->acparam[2].aci = WIFI_WME_AC_VI_ACI;
+		wmm_info->acparam[2].ecw = WIFI_WME_AC_VI_ECW;
+		wmm_info->acparam[2].txop = WIFI_WME_AC_VI_TXOP;
+
+		wmm_info->acparam[3].aci = WIFI_WME_AC_VO_ACI;
+		wmm_info->acparam[3].ecw = WIFI_WME_AC_VO_ECW;
+		wmm_info->acparam[3].txop = WIFI_WME_AC_VO_TXOP;
+
+		ptr += 2 + WIFI_WME_LEN;
+		actual_length += 2 + WIFI_WME_LEN;
 	}
 
 	p->take(max_len - actual_length);

--- a/elements/empower/empowerlvapmanager.cc
+++ b/elements/empower/empowerlvapmanager.cc
@@ -1805,6 +1805,7 @@ int EmpowerLVAPManager::handle_incom_mcast_addr_response(Packet *p, uint32_t off
 	mcs.push_back(*(def_tx_policy->_mcs.begin()));
 
 	Vector<int> ht_mcs;
+	ht_mcs.push_back(*(def_tx_policy->_ht_mcs.begin()));
 
 	_rcs[iface]->tx_policies()->insert(mcast_addr, mcs, ht_mcs, def_tx_policy->_no_ack, TX_MCAST_LEGACY, def_tx_policy->_ur_mcast_count, def_tx_policy->_rts_cts);
 

--- a/include/clicknet/wifi.h
+++ b/include/clicknet/wifi.h
@@ -267,6 +267,66 @@ struct click_wifi_ht_info {
 	uint8_t		rx_supported_mcs[16];
 } CLICK_SIZE_PACKED_ATTRIBUTE;
 
+
+/*
+ * WMM/WME Information Element
+ */
+
+/* WMM/WME Elements */
+#define WIFI_WME_LEN				24
+#define WIFI_WME_OUI				"\x00\x50\xf2"
+#define WIFI_WME_OUI_LEN			3
+#define WIFI_WME_TYPE				0x02
+#define WIFI_WME_SUBTYPE			1
+#define WIFI_WME_VERSION			1
+
+/* EDCA categories */
+#define AC_BE			0
+#define AC_BK			1
+#define AC_VI			2
+#define AC_VO			3
+#define AC_COUNT		4
+
+/* EDCA Values */
+#define WIFI_WME_AC_BE_ACI      	0x03
+#define WIFI_WME_AC_BE_ECW  		0xA4
+#define WIFI_WME_AC_BE_TXOP      	0x0000
+
+#define WIFI_WME_AC_BK_ACI      	0x27
+#define WIFI_WME_AC_BK_ECW       	0xA4
+#define WIFI_WME_AC_BK_TXOP        	0x0000
+
+#define WIFI_WME_AC_VI_ACI         	0x42
+#define WIFI_WME_AC_VI_ECW         	0x43
+#define WIFI_WME_AC_VI_TXOP       	0x005E
+
+#define WIFI_WME_AC_VO_ACI        	0x62
+#define WIFI_WME_AC_VO_ECW        	0x32
+#define WIFI_WME_AC_VO_TXOP       	0x002F
+
+/* WME QoS Info */
+#define WIFI_WME_APSD_MASK         	0x80
+#define WIFI_WME_APSD_SHIFT        	7
+
+struct edca_ac_param {
+	uint8_t   		aci;
+	uint8_t   		ecw;
+	uint16_t  		txop;
+} CLICK_SIZE_PACKED_ATTRIBUTE;
+
+/* WMM/WME Parameter Element */
+struct click_wifi_wmm {
+	uint8_t			tag_type;
+	uint8_t			len;
+	char			oui[WIFI_WME_OUI_LEN];
+	uint8_t 		type;
+	uint8_t 		subtype;
+	uint8_t 		version;
+	uint8_t 		qosinfo;
+	uint8_t 		reserved;
+	edca_ac_param 	acparam[AC_COUNT];
+} CLICK_SIZE_PACKED_ATTRIBUTE;
+
 #define WIFI_RATES_MAXSIZE	15
 #define WIFI_NWID_MAXSIZE	32
 


### PR DESCRIPTION
- The 802.11n assocation problems have been fixed. Clients can normally associate as 802.11n stations.
- Added support in the management frames for WMM/WME. 
