### PR TITLE
add quantum info to read handler + fix slice update

### DIFF
--- a/elements/empower/empowerqosmanager.cc
+++ b/elements/empower/empowerqosmanager.cc
@@ -323,22 +323,26 @@ void EmpowerQOSManager::set_default_slice(String ssid) {
 void EmpowerQOSManager::set_slice(String ssid, int dscp, uint32_t quantum, bool amsdu_aggregation) {
 	_lock.acquire_write();
 	Slice slice = Slice(ssid, dscp);
-	if (_slices.find(slice) == _slices.end()) {
-		if (_debug) {
-			click_chatter("%{element} :: %s :: Creating new slice queue for ssid %s dscp %u quantum %u A-MSDU %s",
-						  this,
-						  __func__,
-						  slice._ssid.c_str(),
-						  slice._dscp,
-						  quantum,
-						  amsdu_aggregation ? "yes." : "no");
-		}
-		uint32_t tr_quantum = (quantum == 0) ? _quantum : quantum;
-		SliceQueue *queue = new SliceQueue(slice, _capacity, tr_quantum, amsdu_aggregation);
-		_slices.set(slice, queue);
-		_head_table.set(slice, 0);
-		_el->send_status_slice(ssid, dscp, _iface_id);
+
+	if (_slices.find(slice) != _slices.end()) {
+		del_slice(ssid, dscp);
 	}
+
+	if (_debug) {
+		click_chatter("%{element} :: %s :: Creating new slice queue for ssid %s dscp %u quantum %u A-MSDU %s",
+					  this,
+					  __func__,
+					  slice._ssid.c_str(),
+					  slice._dscp,
+					  quantum,
+					  amsdu_aggregation ? "yes." : "no");
+	}
+	uint32_t tr_quantum = (quantum == 0) ? _quantum : quantum;
+	SliceQueue *queue = new SliceQueue(slice, _capacity, tr_quantum, amsdu_aggregation);
+	_slices.set(slice, queue);
+	_head_table.set(slice, 0);
+	_el->send_status_slice(ssid, dscp, _iface_id);
+
 	_lock.release_write();
 }
 

--- a/elements/empower/empowerqosmanager.hh
+++ b/elements/empower/empowerqosmanager.hh
@@ -358,7 +358,9 @@ public:
 
 	String unparse() {
 		StringAccum result;
-		result << _slice.unparse() << " -> capacity: " << _capacity << "\n";
+		result << _slice.unparse();
+		result << " -> capacity: " << _capacity << ", ";
+		result << "quantum: " << _quantum << "\n";
 		AQIter itr = _queues.begin();
 		while (itr != _queues.end()) {
 			AggregationQueue *aq = itr.value();


### PR DESCRIPTION
Regarding the double lock acquisition:

https://github.com/kohler/click/blob/master/include/click/sync.hh

/** @brief Acquires the ReadWriteLock for writing.
 *
 * On return, this thread has acquired the lock for writing.  The function
 * will spin indefinitely until the lock is acquired.  It is OK to acquire a
 * lock you have already acquired, but you must release it as many times as
 * you have acquired it.
 *
 * @sa ReadWriteLock::acquire_read
 */
inline void
ReadWriteLock::acquire_write()
{
#if CLICK_LINUXMODULE && defined(CONFIG_SMP)
    for (unsigned i = 0; i < (unsigned) num_possible_cpus(); i++)
	_l[i]._lock.acquire();
#endif
}