### PR TITLE
Fixing empower_del_lvap packet order

### DIFF
--- a/elements/empower/empowerpacket.hh
+++ b/elements/empower/empowerpacket.hh
@@ -467,9 +467,9 @@ struct empower_del_lvap : public empower_header {
   private:
     uint32_t _module_id;          /* Transaction id */
     uint8_t _sta[6];              /* EtherAddress */
-    uint8_t _csa_switch_channel;  /* WiFi channel (int) */
     uint8_t _csa_switch_mode;
     uint8_t _csa_switch_count;
+    uint8_t _csa_switch_channel;  /* WiFi channel (int) */
   public:
     uint32_t module_id()            { return ntohl(_module_id); }
     EtherAddress sta()              { return EtherAddress(_sta); }


### PR DESCRIPTION
Hello,

I realized that the order of the fields from the empower_del_lvap packet was inconsistent. 

On the controller, fields are sent in the following order: csa_switch_mode, csa_switch_count, and csa_switch_channel. On the other hand, the AP treating the message with as following: _csa_switch_channel, _csa_switch_mode, and _csa_switch_count.

Therefore, I made the change and works as expected.

Best Regards,